### PR TITLE
allow users to specify the ssl context

### DIFF
--- a/barista/src/main/java/com/markelliot/barista/Server.java
+++ b/barista/src/main/java/com/markelliot/barista/Server.java
@@ -123,7 +123,7 @@ public final class Server {
             return this;
         }
 
-        public Builder setSslContext(SSLContext context) {
+        public Builder sslContext(SSLContext context) {
             Objects.requireNonNull(context);
             this.sslContext = Optional.of(context);
             return this;

--- a/barista/src/main/java/com/markelliot/barista/Server.java
+++ b/barista/src/main/java/com/markelliot/barista/Server.java
@@ -169,8 +169,11 @@ public final class Server {
         private ListenerBuilder listener() {
             ListenerBuilder lb = new ListenerBuilder().setPort(port).setHost("0.0.0.0");
             if (tls) {
-                SSLContext context = sslContext.orElseGet(() ->
-                        TransportLayerSecurity.createSslContext(Paths.get("var", "security")));
+                SSLContext context =
+                        sslContext.orElseGet(
+                                () ->
+                                        TransportLayerSecurity.createSslContext(
+                                                Paths.get("var", "security")));
                 lb.setType(ListenerType.HTTPS).setSslContext(context);
             } else {
                 lb.setType(ListenerType.HTTP);


### PR DESCRIPTION
Previously users only had the option of enabling or disabling SSL but they were forced to always use the sslContext built by barista.

Now users can provide their own ssl context if they would like to construct it differently