### PR TITLE
Support 128 bit traceIds

### DIFF
--- a/barista/src/main/java/com/markelliot/barista/handlers/TracingHandler.java
+++ b/barista/src/main/java/com/markelliot/barista/handlers/TracingHandler.java
@@ -67,7 +67,7 @@ public record TracingHandler(double rate, HttpHandler delegate) implements HttpH
     /** Gets the value of the named header the request and returns it if safe to handle. */
     private static String getId(HttpServerExchange exchange, String header) {
         String val = exchange.getRequestHeaders().getFirst(header);
-        if (val != null && val.length() < 32) {
+        if (val != null && val.length() <= 32) {
             return val;
         }
         return null;


### PR DESCRIPTION
The zipkin spec outlines how traceIds can either be 64 or 128bits encoded as 16 or 32 lower hex character, https://github.com/openzipkin/b3-propagation#traceid-1.

The Barista implementation would silently drop 128bit traceIds