### PR TITLE
Do not rewrite query parameters 

### DIFF
--- a/barista/src/main/java/com/markelliot/barista/handlers/EndpointHandlerBuilder.java
+++ b/barista/src/main/java/com/markelliot/barista/handlers/EndpointHandlerBuilder.java
@@ -35,7 +35,7 @@ public final class EndpointHandlerBuilder {
 
     public HttpHandler build(Set<EndpointHandler> endpointHandlers) {
         EndpointRuntime runtime = new EndpointRuntime(serde, authz);
-        RoutingHandler router = new RoutingHandler();
+        RoutingHandler router = new RoutingHandler(false);
         endpointHandlers.forEach(e -> router.add(e.method().method(), e.route(), e.handler(runtime)));
         router.setFallbackHandler(
                 exchange -> exchange.setStatusCode(404).getResponseSender().send("Unknown API Endpoint"));


### PR DESCRIPTION
## Before this PR
We had relied on the default constructor of the RoutingHandler which would inject all matching path parameters as query parameters in the HttpServerExchange.

## After this PR
Do not rewrite query parameters 

## Possible downsides?
There may be some consumer that relies on the current behaviour, but to my knowledge consumers extract the path parameters themselves
