### PR TITLE
Expose fallback callback

### DIFF
--- a/barista/src/main/java/com/markelliot/barista/Request.java
+++ b/barista/src/main/java/com/markelliot/barista/Request.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2023 Mark Elliot. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.markelliot.barista;
+
+import com.google.common.collect.ListMultimap;
+
+public record Request(
+        String path, ListMultimap<String, String> headerParams, ListMultimap<String, String> queryParams) {}

--- a/barista/src/main/java/com/markelliot/barista/Server.java
+++ b/barista/src/main/java/com/markelliot/barista/Server.java
@@ -179,11 +179,10 @@ public final class Server {
                 Spans.register("barista", span -> tracing.info("TRACING {}", span));
             }
 
-            EndpointHandlerBuilder handler = new EndpointHandlerBuilder(fallbackHandler, serde, authz);
             HttpHandler handlerChain = HandlerChain.of(DispatchFromIoThreadHandler::new)
                     .then(h -> new CorsHandler(allowAllOrigins, allowedOrigins, h))
                     .then(h -> new TracingHandler(tracingRate, h))
-                    .last(new EndpointHandlerBuilder(fallbackHandler, serde, authz).build(endpointHandlers));
+                    .last(new EndpointHandlerBuilder(serde, authz, fallbackHandler).build(endpointHandlers));
             GracefulShutdownHandler shutdownHandler = new GracefulShutdownHandler(handlerChain);
             Undertow undertow = Undertow.builder()
                     .setHandler(new DispatchFromIoThreadHandler(shutdownHandler))

--- a/barista/src/main/java/com/markelliot/barista/handlers/EndpointHandlerBuilder.java
+++ b/barista/src/main/java/com/markelliot/barista/handlers/EndpointHandlerBuilder.java
@@ -16,19 +16,29 @@
 
 package com.markelliot.barista.handlers;
 
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimaps;
+import com.markelliot.barista.Request;
 import com.markelliot.barista.SerDe;
 import com.markelliot.barista.authz.Authz;
 import com.markelliot.barista.endpoints.EndpointHandler;
 import com.markelliot.barista.endpoints.EndpointRuntime;
 import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
 import io.undertow.server.RoutingHandler;
+import java.util.ArrayList;
+import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Consumer;
 
 public final class EndpointHandlerBuilder {
+    private final Optional<Consumer<Request>> fallbackHandler;
     private final SerDe serde;
     private final Authz authz;
 
-    public EndpointHandlerBuilder(SerDe serde, Authz authz) {
+    public EndpointHandlerBuilder(Optional<Consumer<Request>> fallbackHandler, SerDe serde, Authz authz) {
+        this.fallbackHandler = fallbackHandler;
         this.serde = serde;
         this.authz = authz;
     }
@@ -37,8 +47,24 @@ public final class EndpointHandlerBuilder {
         EndpointRuntime runtime = new EndpointRuntime(serde, authz);
         RoutingHandler router = new RoutingHandler(false);
         endpointHandlers.forEach(e -> router.add(e.method().method(), e.route(), e.handler(runtime)));
-        router.setFallbackHandler(
-                exchange -> exchange.setStatusCode(404).getResponseSender().send("Unknown API Endpoint"));
+        router.setFallbackHandler(exchange -> {
+            fallbackHandler.ifPresent(requestConsumer -> requestConsumer.accept(toRequest(exchange)));
+            exchange.setStatusCode(404).getResponseSender().send("Unknown API Endpoint");
+        });
         return router;
+    }
+
+    private static Request toRequest(HttpServerExchange exchange) {
+        ListMultimap<String, String> headers =
+                Multimaps.newListMultimap(new TreeMap<>(String.CASE_INSENSITIVE_ORDER), ArrayList::new);
+        ListMultimap<String, String> queryParams =
+                Multimaps.newListMultimap(new TreeMap<>(String.CASE_INSENSITIVE_ORDER), ArrayList::new);
+
+        exchange.getQueryParameters().forEach(queryParams::putAll);
+        exchange.getRequestHeaders().forEach(headerValue -> {
+            headers.putAll(headerValue.getHeaderName().toString(), headerValue);
+        });
+
+        return new Request(exchange.getRequestPath(), headers, queryParams);
     }
 }

--- a/barista/src/main/java/com/markelliot/barista/handlers/EndpointHandlerBuilder.java
+++ b/barista/src/main/java/com/markelliot/barista/handlers/EndpointHandlerBuilder.java
@@ -33,11 +33,11 @@ import java.util.TreeMap;
 import java.util.function.Consumer;
 
 public final class EndpointHandlerBuilder {
-    private final Optional<Consumer<Request>> fallbackHandler;
     private final SerDe serde;
     private final Authz authz;
+    private final Optional<Consumer<Request>> fallbackHandler;
 
-    public EndpointHandlerBuilder(Optional<Consumer<Request>> fallbackHandler, SerDe serde, Authz authz) {
+    public EndpointHandlerBuilder(SerDe serde, Authz authz, Optional<Consumer<Request>> fallbackHandler) {
         this.fallbackHandler = fallbackHandler;
         this.serde = serde;
         this.authz = authz;


### PR DESCRIPTION
## Before this PR
It wasn't possible to take any action or collect any metrics when a request did not match any handler

## After this PR
Expose fallback callback

Consumers of this library can register a callback to be called with a read-only view of the request to take what action they would like

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
