### PR TITLE
Fix path parameters

### DIFF
--- a/barista-processor/src/test/java/com/markelliot/barista/processor/FooResource.java
+++ b/barista-processor/src/test/java/com/markelliot/barista/processor/FooResource.java
@@ -54,4 +54,9 @@ public final class FooResource {
     public String openGet() {
         return "Hello, World!";
     }
+
+    @Http.Get("/foo/open/echo/{msg}")
+    public String openEcho(String msg) {
+        return msg;
+    }
 }

--- a/barista-processor/src/test/java/com/markelliot/barista/processor/TestFooServer.java
+++ b/barista-processor/src/test/java/com/markelliot/barista/processor/TestFooServer.java
@@ -51,6 +51,7 @@ public final class TestFooServer {
     @Test
     void smokeTest() throws IOException, InterruptedException {
         assertResponse("http://localhost:8080/foo/open/get", 200, "\"Hello, World!\"");
+        assertResponse("http://localhost:8080/foo/open/echo/hellother", 200, "\"hellother\"");
     }
 
     private void assertResponse(String uri, int statusCode, String expectedResponseText)

--- a/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
+++ b/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
@@ -26,7 +26,6 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
 import io.undertow.util.PathTemplateMatch;
-
 import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;

--- a/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
+++ b/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
@@ -25,7 +25,10 @@ import com.markelliot.result.Result;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
+import io.undertow.util.PathTemplateMatch;
+
 import java.util.Deque;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -126,7 +129,8 @@ public final class EndpointRuntime {
     }
 
     public static Optional<String> pathParameter(String parameter, HttpServerExchange exchange) {
-        return Optional.ofNullable(exchange.getPathParameters().get(parameter)).map(Deque::getFirst);
+        Map<String, String> pathParams = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+        return Optional.ofNullable(pathParams.get(parameter));
     }
 
     public static Optional<String> headerParameter(String parameter, HttpServerExchange exchange) {

--- a/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
+++ b/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
@@ -129,7 +129,8 @@ public final class EndpointRuntime {
     }
 
     public static Optional<String> pathParameter(String parameter, HttpServerExchange exchange) {
-        Map<String, String> pathParams = exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
+        Map<String, String> pathParams =
+                exchange.getAttachment(PathTemplateMatch.ATTACHMENT_KEY).getParameters();
         return Optional.ofNullable(pathParams.get(parameter));
     }
 


### PR DESCRIPTION
Fix path parameters for barista annotations.

`HttpServerExchanget#getPathParameters` is not for path template params, it seems to be for semicolon-separated trailers at the end of the path string. See [these tests](https://github.com/undertow-io/undertow/commit/519e86916340650616f0a8fab3b20836b0f673bd#diff-719b2cd81a69e7a00597ae77d8ff5a6e64b85102d440910041b4bafedd684fdbR71-R77) from when HttpServerExchange#getPathParameters was added to undertow 10 years ago, and also [RFC2396](https://datatracker.ietf.org/doc/html/rfc2396#section-3.3)


cf. [path template parsing code in Conjure](https://github.com/palantir/conjure-java/blob/64e2c2f6d945ecd90bb4dce94105ba8f665ae026/conjure-java-core/src/main/java/com/palantir/conjure/java/services/UndertowServiceHandlerGenerator.java#L700C46-L708).

I updated the smoketest to hit a new `openEcho` endpoint that receives a path param. The test fails without the change to EndpointRuntime.