### PR TITLE
Make actions with secrets safe for forks

### DIFF
--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   autosquash:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Generate token
         id: token

--- a/.github/workflows/required-reviewers.yml
+++ b/.github/workflows/required-reviewers.yml
@@ -6,6 +6,7 @@ jobs:
   required-reviewers:
     name: Required Reviewers
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: required-reviewers
         uses: theoremlp/required-reviews@v2


### PR DESCRIPTION
# Before
autosquash and required-reviewers fail on forks due to needing secrets to run.

# After
Suppress actions that need secrets from running on forks.
