### PR TITLE
SerDe cleanup

### DIFF
--- a/barista-processor/src/main/java/com/markelliot/barista/processor/AnnotationHelpers.java
+++ b/barista-processor/src/main/java/com/markelliot/barista/processor/AnnotationHelpers.java
@@ -17,8 +17,8 @@
 package com.markelliot.barista.processor;
 
 import com.google.common.collect.ImmutableSet;
+import com.markelliot.barista.HttpMethod;
 import com.markelliot.barista.annotations.Http;
-import com.markelliot.barista.processor.EndpointHandlerGenerator.EndpointHandlerDefinition.HttpMethod;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 import java.util.function.Function;

--- a/barista-processor/src/main/java/com/markelliot/barista/processor/EndpointHandlerGenerator.java
+++ b/barista-processor/src/main/java/com/markelliot/barista/processor/EndpointHandlerGenerator.java
@@ -18,8 +18,8 @@ package com.markelliot.barista.processor;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.markelliot.barista.Bytes;
 import com.markelliot.barista.HttpMethod;
-import com.markelliot.barista.SerDe.ByteRepr;
 import com.markelliot.barista.authz.VerifiedAuthToken;
 import com.markelliot.barista.endpoints.EndpointHandler;
 import com.markelliot.barista.endpoints.EndpointRuntime;
@@ -35,6 +35,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -167,14 +168,13 @@ public final class EndpointHandlerGenerator {
                 .ifPresentOrElse(
                         bodyParam -> handler.add(CodeBlock.builder()
                                 .beginControlFlow(
-                                        "$N.getRequestReceiver().receiveFullString((bodyExchange, body_) ->",
-                                        "exchange")
+                                        "$N.getRequestReceiver().receiveFullBytes((bodyExchange, body_) ->", "exchange")
                                 .addStatement(
-                                        "$T $N = $N.serde(bodyExchange).deserialize(new $T(body_), $T.class)",
+                                        "$T $N = $N.requestSerDe(bodyExchange).deserialize($T.from(body_), $T.class)",
                                         bodyParam.className(),
                                         bodyParam.argumentName(),
                                         "runtime",
-                                        ByteRepr.class,
+                                        Bytes.class,
                                         bodyParam.className())
                                 .add(returnStatement)
                                 .endControlFlow(")")
@@ -251,7 +251,7 @@ public final class EndpointHandlerGenerator {
     }
 
     private static String ucfirst(String str) {
-        return str.substring(0, 1).toUpperCase() + str.substring(1);
+        return str.substring(0, 1).toUpperCase(Locale.getDefault()) + str.substring(1);
     }
 
     public record EndpointHandlerDefinition(
@@ -269,13 +269,6 @@ public final class EndpointHandlerGenerator {
                                     .count()
                             <= 1,
                     "At most one body-type parameter allowed");
-        }
-
-        enum HttpMethod {
-            GET,
-            PUT,
-            POST,
-            DELETE
         }
 
         enum ReturnType {

--- a/barista-processor/src/main/java/com/markelliot/barista/processor/EndpointHandlerProcessor.java
+++ b/barista-processor/src/main/java/com/markelliot/barista/processor/EndpointHandlerProcessor.java
@@ -21,11 +21,11 @@ import com.google.common.collect.Multimaps;
 import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.JavaFormatterOptions;
 import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
+import com.markelliot.barista.HttpMethod;
 import com.markelliot.barista.annotations.Param;
 import com.markelliot.barista.authz.VerifiedAuthToken;
 import com.markelliot.barista.endpoints.HttpRedirect;
 import com.markelliot.barista.processor.EndpointHandlerGenerator.EndpointHandlerDefinition;
-import com.markelliot.barista.processor.EndpointHandlerGenerator.EndpointHandlerDefinition.HttpMethod;
 import com.markelliot.barista.processor.EndpointHandlerGenerator.EndpointHandlerDefinition.ReturnType;
 import com.markelliot.barista.processor.EndpointHandlerGenerator.ParameterDefinition;
 import com.markelliot.barista.processor.EndpointHandlerGenerator.ParameterDefinition.ParamType;
@@ -114,6 +114,7 @@ public final class EndpointHandlerProcessor extends AbstractProcessor {
             try {
                 filerSourceFile.delete();
             } catch (Exception ignored) {
+                // ignore
             }
             throw e;
         }

--- a/barista/src/main/java/com/markelliot/barista/Bytes.java
+++ b/barista/src/main/java/com/markelliot/barista/Bytes.java
@@ -1,0 +1,114 @@
+/*
+ * (c) Copyright 2021 Mark Elliot. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.markelliot.barista;
+
+/* Derived from https://github.com/palantir/conjure-java/blob/11a4db9b041de4866089bb6466ad2e4e2a3c98fb/conjure-lib/src/main/java/com/palantir/conjure/java/lib/Bytes.java
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/** An immutable {@code byte[]} wrapper. */
+public final class Bytes {
+    private final byte[] safe;
+    private int hashCode;
+
+    /** Constructs a new {@link Bytes} assuming the provided array is not held by any other class. */
+    private Bytes(byte[] array) {
+        safe = array;
+    }
+
+    /** Returns a new read-only {@link ByteBuffer} backed by this byte array. */
+    public ByteBuffer asReadOnlyByteBuffer() {
+        return ByteBuffer.wrap(safe).asReadOnlyBuffer();
+    }
+
+    /** Returns a new byte array containing the same content as this object's underlying {@code byte[]}. */
+    public byte[] asNewByteArray() {
+        byte[] unsafe = new byte[safe.length];
+        System.arraycopy(safe, 0, unsafe, 0, safe.length);
+        return unsafe;
+    }
+
+    /** Copies this byte array into the provided byte array beginning at offset and up to the provided length. */
+    public void copyTo(byte[] destination, int offset, int length) {
+        System.arraycopy(safe, 0, destination, offset, length);
+    }
+
+    /** Returns a new {@link InputStream} that reads this byte array. */
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(safe);
+    }
+
+    /** Returns the underlying array for unsafe, efficient access within this package scope. */
+    /* package */ byte[] unsafeGetUnderlyingArray() {
+        return safe;
+    }
+
+    /** Returns the size of this byte array. */
+    public int size() {
+        return safe.length;
+    }
+
+    @Override
+    public int hashCode() {
+        // same implementation as java.lang.String except Arrays.hashCode(new byte[0]) == 1 so no length check.
+        int hash = hashCode;
+        if (hash == 0) {
+            hash = Arrays.hashCode(safe);
+            hashCode = hash;
+        }
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || (obj instanceof Bytes bytes && Arrays.equals(safe, bytes.safe));
+    }
+
+    @Override
+    public String toString() {
+        return "Bytes{size: " + safe.length + '}';
+    }
+
+    /** Constructs a new {@link Bytes} from the provided array. */
+    public static Bytes from(byte[] array) {
+        return from(array, 0, array.length);
+    }
+
+    /** Constructs a new {@link Bytes} read from provided offset for the provided length. */
+    public static Bytes from(byte[] array, int offset, int length) {
+        byte[] safe = new byte[length];
+        System.arraycopy(array, offset, safe, 0, length);
+
+        return new Bytes(safe);
+    }
+
+    /** Constructs a new {@link Bytes} read from the provided {@link ByteBuffer}. */
+    public static Bytes from(ByteBuffer buffer) {
+        // call duplicate to ensure we don't mutate the provided ByteBuffer while copying
+        ByteBuffer local = buffer.duplicate();
+
+        byte[] safe = new byte[local.remaining()];
+        local.get(safe);
+
+        return new Bytes(safe);
+    }
+}

--- a/barista/src/main/java/com/markelliot/barista/SerDe.java
+++ b/barista/src/main/java/com/markelliot/barista/SerDe.java
@@ -29,9 +29,9 @@ import com.google.common.net.MediaType;
 import java.io.IOException;
 
 public interface SerDe {
-    <T> ByteRepr serialize(T any);
+    <T> Bytes serialize(T any);
 
-    <T> T deserialize(ByteRepr bytes, Class<T> objClass);
+    <T> T deserialize(Bytes bytes, Class<T> objClass);
 
     String contentType();
 
@@ -39,20 +39,18 @@ public interface SerDe {
         return this;
     }
 
-    record ByteRepr(String raw) {}
-
     final class MimeTypeDispatchingSerDe implements SerDe {
         public static final SerDe INSTANCE = new MimeTypeDispatchingSerDe();
 
         private MimeTypeDispatchingSerDe() {}
 
         @Override
-        public <T> ByteRepr serialize(T any) {
+        public <T> Bytes serialize(T any) {
             return ObjectMapperSerDe.JSON.serialize(any);
         }
 
         @Override
-        public <T> T deserialize(ByteRepr bytes, Class<T> objClass) {
+        public <T> T deserialize(Bytes bytes, Class<T> objClass) {
             return ObjectMapperSerDe.JSON.deserialize(bytes, objClass);
         }
 
@@ -92,18 +90,18 @@ public interface SerDe {
         }
 
         @Override
-        public <T> ByteRepr serialize(T any) {
+        public <T> Bytes serialize(T any) {
             try {
-                return new ByteRepr(mapper.writeValueAsString(any));
+                return Bytes.from(mapper.writeValueAsBytes(any));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException("Error while serializing object to bytes", e);
             }
         }
 
         @Override
-        public <T> T deserialize(ByteRepr bytes, Class<T> objClass) {
+        public <T> T deserialize(Bytes bytes, Class<T> objClass) {
             try {
-                return mapper.readValue(bytes.raw(), objClass);
+                return mapper.readValue(bytes.unsafeGetUnderlyingArray(), objClass);
             } catch (IOException e) {
                 throw new RuntimeException("Error while deserializing object from bytes", e);
             }

--- a/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
+++ b/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
@@ -41,14 +41,10 @@ public final class EndpointRuntime {
         this.authz = authz;
     }
 
-    public SerDe serde() {
-        return serde;
-    }
-
-    public SerDe serde(HttpServerExchange exchange) {
+    public SerDe requestSerDe(HttpServerExchange exchange) {
         HeaderValues headers = exchange.getRequestHeaders().get(Headers.CONTENT_TYPE);
         if (headers.isEmpty()) {
-            return serde();
+            return serde;
         }
         return serde.forMimeType(headers.getFirst());
     }
@@ -107,12 +103,12 @@ public final class EndpointRuntime {
         exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, serde.contentType());
         exchange.getResponseSender()
                 .send(serde.serialize(new ServerError(UUID.randomUUID().toString(), error.message()))
-                        .raw());
+                        .asReadOnlyByteBuffer());
     }
 
     private void writeBody(Object body, HttpServerExchange exchange) {
         exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, serde.contentType());
-        exchange.getResponseSender().send(serde.serialize(body).raw());
+        exchange.getResponseSender().send(serde.serialize(body).asReadOnlyByteBuffer());
     }
 
     private void writeEmpty(HttpServerExchange exchange) {
@@ -127,7 +123,7 @@ public final class EndpointRuntime {
     private void writeError(ServerError error, HttpServerExchange exchange) {
         exchange.setStatusCode(500);
         exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, serde.contentType());
-        exchange.getResponseSender().send(serde.serialize(error).raw());
+        exchange.getResponseSender().send(serde.serialize(error).asReadOnlyByteBuffer());
     }
 
     private static void redirect(HttpRedirect redirect, HttpServerExchange exchange) {

--- a/barista/src/main/java/com/markelliot/barista/tls/TransportLayerSecurity.java
+++ b/barista/src/main/java/com/markelliot/barista/tls/TransportLayerSecurity.java
@@ -374,14 +374,7 @@ public final class TransportLayerSecurity {
 
         @Override
         public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (!(obj instanceof EqualByteArray)) {
-                return false;
-            }
-            EqualByteArray other = (EqualByteArray) obj;
-            return Arrays.equals(this.bytes, other.bytes);
+            return this == obj || (obj instanceof EqualByteArray other && Arrays.equals(bytes, other.bytes));
         }
     }
 


### PR DESCRIPTION
* Update SerDe to use an immutable Bytes repr instead of ByteRepr backed by String.
* Delete unused EndpointRuntime#serde()
* Update EndpointRuntime#serde(Exchange) to `requestSerDe`

All of this is in preparation for more careful handling of an incoming `Accept` header and also creating space for `byte[]` backed reprs (like protobuf).
