### PR TITLE
Try to respect Accept header

### DIFF
--- a/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
+++ b/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
@@ -49,6 +49,17 @@ public final class EndpointRuntime {
         return serde.forMimeType(headers.getFirst());
     }
 
+    private SerDe responseSerDe(HttpServerExchange exchange) {
+        HeaderValues headers = exchange.getRequestHeaders().get(Headers.ACCEPT);
+        for (String accept : headers) {
+            SerDe candidate = serde.forMimeType(accept);
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+        return serde;
+    }
+
     public Result<VerifiedAuthToken, HttpError> verifyAuth(HttpServerExchange exchange) {
         HeaderValues authzHeader = exchange.getRequestHeaders().get(Headers.AUTHORIZATION);
         if (authzHeader.size() != 1) {
@@ -107,13 +118,15 @@ public final class EndpointRuntime {
     }
 
     private void writeBody(Object body, HttpServerExchange exchange) {
-        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, serde.contentType());
-        exchange.getResponseSender().send(serde.serialize(body).asReadOnlyByteBuffer());
+        SerDe responseSerDe = responseSerDe(exchange);
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, responseSerDe.contentType());
+        exchange.getResponseSender().send(responseSerDe.serialize(body).asReadOnlyByteBuffer());
     }
 
     private void writeEmpty(HttpServerExchange exchange) {
+        SerDe responseSerDe = responseSerDe(exchange);
         exchange.setStatusCode(201);
-        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, serde.contentType());
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, responseSerDe.contentType());
     }
 
     private void writeError(Exception exception, HttpServerExchange exchange) {
@@ -121,9 +134,10 @@ public final class EndpointRuntime {
     }
 
     private void writeError(ServerError error, HttpServerExchange exchange) {
+        SerDe responseSerDe = responseSerDe(exchange);
         exchange.setStatusCode(500);
-        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, serde.contentType());
-        exchange.getResponseSender().send(serde.serialize(error).asReadOnlyByteBuffer());
+        exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, responseSerDe.contentType());
+        exchange.getResponseSender().send(responseSerDe.serialize(error).asReadOnlyByteBuffer());
     }
 
     private static void redirect(HttpRedirect redirect, HttpServerExchange exchange) {

--- a/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
+++ b/barista/src/main/java/com/markelliot/barista/endpoints/EndpointRuntime.java
@@ -43,7 +43,7 @@ public final class EndpointRuntime {
 
     public SerDe requestSerDe(HttpServerExchange exchange) {
         HeaderValues headers = exchange.getRequestHeaders().get(Headers.CONTENT_TYPE);
-        if (headers.isEmpty()) {
+        if (headers == null || headers.isEmpty()) {
             return serde;
         }
         return serde.forMimeType(headers.getFirst());
@@ -51,10 +51,12 @@ public final class EndpointRuntime {
 
     private SerDe responseSerDe(HttpServerExchange exchange) {
         HeaderValues headers = exchange.getRequestHeaders().get(Headers.ACCEPT);
-        for (String accept : headers) {
-            SerDe candidate = serde.forMimeType(accept);
-            if (candidate != null) {
-                return candidate;
+        if (headers != null) {
+            for (String accept : headers) {
+                SerDe candidate = serde.forMimeType(accept);
+                if (candidate != null) {
+                    return candidate;
+                }
             }
         }
         return serde;

--- a/barista/src/test/java/com/markelliot/barista/ServerTests.java
+++ b/barista/src/test/java/com/markelliot/barista/ServerTests.java
@@ -64,7 +64,7 @@ final class ServerTests {
 
     @AfterAll
     static void afterAll() {
-        server.stop();
+        new Thread(server::stop).start();
     }
 
     @Test


### PR DESCRIPTION
Add a responseSerDe selector that iterates through accept headers.

When the Accept header does not result in a matching SerDe, Barista will use the default SerDe (this maintains the current behavior).

Note that this change only affects those using Barista's EndpointRuntime (e.g. codegen users).
