### PR TITLE
Update GracefulShutdownHandler usage

### DIFF
--- a/barista/src/main/java/com/markelliot/barista/Server.java
+++ b/barista/src/main/java/com/markelliot/barista/Server.java
@@ -72,10 +72,11 @@ public final class Server {
      */
     public synchronized void stop() {
         shutdownHandler.shutdown();
-        shutdownHandler.addShutdownListener(shutdownSuccessful -> undertow.stop());
         try {
             if (!shutdownHandler.awaitShutdown(SHUTDOWN_TIMEOUT.toMillis())) {
-                log.warn("Graceful shutdown handler exceeded wait.");
+                log.warn("Graceful shutdown handler exceeded wait");
+            } else {
+                log.info("Graceful shutdown complete");
             }
         } catch (InterruptedException e) {
             log.error("Interrupted while waiting for graceful shutdown", e);


### PR DESCRIPTION
We’ve been seeing some test hangs while trying to stop the server. #394 shows a suspicious thread where we seem to end up with a deadlock preventing shutdown. 

Update our shutdown procedure to remove the GracefulShutdownHandler’s shutdown hook, which attempts to shutdown Undertow from the XNIO threads Undertow manages, and rely on a subsequent common call to undertow’s shutdown function. 