### PR TITLE
Fix publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,15 @@
 import com.google.cloud.tools.jib.gradle.JibExtension
 import net.ltgt.gradle.errorprone.errorprone
 
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            // Fix https://github.com/jreleaser/jreleaser/issues/1643
+            force("org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r")
+        }
+    }
+}
+
 plugins {
     idea
     id("com.diffplug.spotless") version "8.0.0"


### PR DESCRIPTION
Publishing broke with the upgrade to jreleaser 1.20.0, which has a subtle dependency conflict with Spotless. Fix publishing by resolving the conflict.

Fixes #440 
