### PR TITLE
expose HTTP PATCH method

### DIFF
--- a/barista-annotations/src/main/java/com/markelliot/barista/annotations/Http.java
+++ b/barista-annotations/src/main/java/com/markelliot/barista/annotations/Http.java
@@ -29,6 +29,10 @@ public @interface Http {
         String value();
     }
 
+    @interface Patch {
+        String value();
+    }
+
     @interface Delete {
         String value();
     }

--- a/barista-conjure/src/main/java/com/markelliot/barista/conjure/ConjureAdapter.java
+++ b/barista-conjure/src/main/java/com/markelliot/barista/conjure/ConjureAdapter.java
@@ -58,6 +58,7 @@ public final class ConjureAdapter {
                 switch (endpoint.method().toString()) {
                     case "GET" -> HttpMethod.GET;
                     case "PUT" -> HttpMethod.PUT;
+                    case "PATCH" -> HttpMethod.PATCH;
                     case "POST" -> HttpMethod.POST;
                     case "DELETE" -> HttpMethod.DELETE;
                     default -> throw new IllegalStateException("Unsupported HTTP method " + endpoint.method());

--- a/barista-processor/src/main/java/com/markelliot/barista/processor/AnnotationHelpers.java
+++ b/barista-processor/src/main/java/com/markelliot/barista/processor/AnnotationHelpers.java
@@ -34,6 +34,7 @@ public final class AnnotationHelpers {
             new EndpointAnnotation(Http.Get.class, HttpMethod.GET, a -> ((Http.Get) a).value()),
             new EndpointAnnotation(Http.Post.class, HttpMethod.POST, a -> ((Http.Post) a).value()),
             new EndpointAnnotation(Http.Put.class, HttpMethod.PUT, a -> ((Http.Put) a).value()),
+            new EndpointAnnotation(Http.Patch.class, HttpMethod.PATCH, a -> ((Http.Patch) a).value()),
             new EndpointAnnotation(Http.Delete.class, HttpMethod.DELETE, a -> ((Http.Delete) a).value()));
 
     private static Set<Class<? extends Annotation>> ENDPOINT_ANNOTATION_CLASSES = ENDPOINT_ANNOTATIONS.stream()

--- a/barista/src/main/java/com/markelliot/barista/HttpMethod.java
+++ b/barista/src/main/java/com/markelliot/barista/HttpMethod.java
@@ -23,6 +23,7 @@ import io.undertow.util.Methods;
 public enum HttpMethod {
     GET(Methods.GET),
     PUT(Methods.PUT),
+    PATCH(Methods.PATCH),
     POST(Methods.POST),
     DELETE(Methods.DELETE);
 

--- a/barista/src/main/java/com/markelliot/barista/handlers/CorsHandler.java
+++ b/barista/src/main/java/com/markelliot/barista/handlers/CorsHandler.java
@@ -31,7 +31,7 @@ public final class CorsHandler implements HttpHandler {
     private static final String ORIGIN_ALL = "*";
 
     private static final HttpString ACCESS_CONTROL_ALLOW_METHODS = new HttpString("Access-Control-Allow-Methods");
-    private static final String ALLOWED_METHODS = "GET, PUT, POST, DELETE";
+    private static final String ALLOWED_METHODS = "GET, PUT, PATCH, POST, DELETE";
 
     private static final HttpString ACCESS_CONTROL_MAX_AGE = new HttpString("Access-Control-Max-Age");
     private static final String ONE_DAY_IN_SECONDS = "86400";


### PR DESCRIPTION
Add support for Undertow HTTP PATCH

Conjure does not support PATCH but can be used with a custom endpoint.