### PR TITLE
allow for duplicate subject DNs in cas.pem

### DIFF
--- a/barista/src/main/java/com/markelliot/barista/tls/DefaultCas.java
+++ b/barista/src/main/java/com/markelliot/barista/tls/DefaultCas.java
@@ -30,6 +30,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -51,22 +52,35 @@ final class DefaultCas {
     }
 
     private static Map<String, X509Certificate> getTrustedCertificates() {
-        ImmutableMap.Builder<String, X509Certificate> certificateMap = ImmutableMap.builder();
         try {
             List<X509Certificate> caCertificates =
                     TransportLayerSecurity.readX509Certificates(new FileInputStream(CA_PEM_FILE)).stream()
                             .map(cert -> (X509Certificate) cert)
                             .collect(Collectors.toList());
-            for (X509Certificate cert : caCertificates) {
-                String certificateCommonName =
-                        cert.getSubjectX500Principal().getName().toLowerCase(Locale.ENGLISH);
-                certificateMap.put(certificateCommonName, cert);
-            }
+            return getTrustedCertificates(caCertificates);
         } catch (CertificateException | IOException e) {
             throw new RuntimeException("Could not read file as an X.509 certificate", e);
         }
+    }
 
+    static Map<String, X509Certificate> getTrustedCertificates(List<X509Certificate> caCertificates) {
+        ImmutableMap.Builder<String, X509Certificate> certificateMap = ImmutableMap.builder();
+        Map<String, Long> subjectCounts = caCertificates.stream()
+                .collect(Collectors.groupingBy(DefaultCas::certificateAlias, Collectors.counting()));
+        Map<String, Integer> duplicateSubjectIndexes = new HashMap<>();
+        for (X509Certificate cert : caCertificates) {
+            String certificateAlias = certificateAlias(cert);
+            if (subjectCounts.get(certificateAlias) > 1) {
+                int index = duplicateSubjectIndexes.merge(certificateAlias, 1, Integer::sum);
+                certificateAlias = certificateAlias + "-" + index;
+            }
+            certificateMap.put(certificateAlias, cert);
+        }
         return certificateMap.build();
+    }
+
+    private static String certificateAlias(X509Certificate cert) {
+        return cert.getSubjectX500Principal().getName().toLowerCase(Locale.ENGLISH);
     }
 
     private DefaultCas() {}

--- a/barista/src/test/java/com/markelliot/barista/tls/DefaultCasTest.java
+++ b/barista/src/test/java/com/markelliot/barista/tls/DefaultCasTest.java
@@ -44,15 +44,15 @@ final class DefaultCasTest {
 
     @Test
     void allowsMultipleCertificatesWithTheSameSubject() {
-        X509Certificate firstCertificate = new TestCertificate("CN=rubix-tenant-ca");
-        X509Certificate secondCertificate = new TestCertificate("CN=rubix-tenant-ca");
+        X509Certificate firstCertificate = new TestCertificate("CN=tenant");
+        X509Certificate secondCertificate = new TestCertificate("CN=tenant");
 
         Map<String, X509Certificate> certificates =
                 DefaultCas.getTrustedCertificates(List.of(firstCertificate, secondCertificate));
 
-        assertThat(certificates.keySet()).containsExactly("cn=rubix-tenant-ca-1", "cn=rubix-tenant-ca-2");
-        assertThat(certificates.get("cn=rubix-tenant-ca-1")).isSameAs(firstCertificate);
-        assertThat(certificates.get("cn=rubix-tenant-ca-2")).isSameAs(secondCertificate);
+        assertThat(certificates.keySet()).containsExactly("cn=tenant-1", "cn=tenant-2");
+        assertThat(certificates.get("cn=tenant-1")).isSameAs(firstCertificate);
+        assertThat(certificates.get("cn=tenant-2")).isSameAs(secondCertificate);
     }
 
     private static final class TestCertificate extends X509Certificate {

--- a/barista/src/test/java/com/markelliot/barista/tls/DefaultCasTest.java
+++ b/barista/src/test/java/com/markelliot/barista/tls/DefaultCasTest.java
@@ -1,0 +1,192 @@
+/*
+ * (c) Copyright 2021 Mark Elliot. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.markelliot.barista.tls;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.security.auth.x500.X500Principal;
+import org.junit.jupiter.api.Test;
+
+final class DefaultCasTest {
+    @Test
+    void preservesSubjectAliasForUniqueCertificates() {
+        X509Certificate certificate = new TestCertificate("CN=unique-ca");
+
+        Map<String, X509Certificate> certificates = DefaultCas.getTrustedCertificates(List.of(certificate));
+
+        assertThat(certificates.keySet()).containsExactly("cn=unique-ca");
+        assertThat(certificates.get("cn=unique-ca")).isSameAs(certificate);
+    }
+
+    @Test
+    void allowsMultipleCertificatesWithTheSameSubject() {
+        X509Certificate firstCertificate = new TestCertificate("CN=rubix-tenant-ca");
+        X509Certificate secondCertificate = new TestCertificate("CN=rubix-tenant-ca");
+
+        Map<String, X509Certificate> certificates =
+                DefaultCas.getTrustedCertificates(List.of(firstCertificate, secondCertificate));
+
+        assertThat(certificates.keySet()).containsExactly("cn=rubix-tenant-ca-1", "cn=rubix-tenant-ca-2");
+        assertThat(certificates.get("cn=rubix-tenant-ca-1")).isSameAs(firstCertificate);
+        assertThat(certificates.get("cn=rubix-tenant-ca-2")).isSameAs(secondCertificate);
+    }
+
+    private static final class TestCertificate extends X509Certificate {
+        private final X500Principal subject;
+
+        private TestCertificate(String subject) {
+            this.subject = new X500Principal(subject);
+        }
+
+        @Override
+        public X500Principal getSubjectX500Principal() {
+            return subject;
+        }
+
+        @Override
+        public void checkValidity() {}
+
+        @Override
+        public void checkValidity(Date date) {}
+
+        @Override
+        public int getVersion() {
+            return 3;
+        }
+
+        @Override
+        public BigInteger getSerialNumber() {
+            return BigInteger.ONE;
+        }
+
+        @Override
+        public Principal getIssuerDN() {
+            return subject;
+        }
+
+        @Override
+        public Principal getSubjectDN() {
+            return subject;
+        }
+
+        @Override
+        public Date getNotBefore() {
+            return new Date(0);
+        }
+
+        @Override
+        public Date getNotAfter() {
+            return new Date(0);
+        }
+
+        @Override
+        public byte[] getTBSCertificate() throws CertificateEncodingException {
+            return new byte[0];
+        }
+
+        @Override
+        public byte[] getSignature() {
+            return new byte[0];
+        }
+
+        @Override
+        public String getSigAlgName() {
+            return "";
+        }
+
+        @Override
+        public String getSigAlgOID() {
+            return "";
+        }
+
+        @Override
+        public byte[] getSigAlgParams() {
+            return new byte[0];
+        }
+
+        @Override
+        public boolean[] getIssuerUniqueID() {
+            return new boolean[0];
+        }
+
+        @Override
+        public boolean[] getSubjectUniqueID() {
+            return new boolean[0];
+        }
+
+        @Override
+        public boolean[] getKeyUsage() {
+            return new boolean[0];
+        }
+
+        @Override
+        public int getBasicConstraints() {
+            return -1;
+        }
+
+        @Override
+        public byte[] getEncoded() throws CertificateEncodingException {
+            return new byte[0];
+        }
+
+        @Override
+        public void verify(PublicKey key) throws CertificateException {}
+
+        @Override
+        public void verify(PublicKey key, String sigProvider) throws CertificateException {}
+
+        @Override
+        public String toString() {
+            return subject.toString();
+        }
+
+        @Override
+        public PublicKey getPublicKey() {
+            return null;
+        }
+
+        @Override
+        public boolean hasUnsupportedCriticalExtension() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getCriticalExtensionOIDs() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<String> getNonCriticalExtensionOIDs() {
+            return Set.of();
+        }
+
+        @Override
+        public byte[] getExtensionValue(String oid) {
+            return new byte[0];
+        }
+    }
+}


### PR DESCRIPTION
I have a situation where rotated CAs are showing up in a cas.pem provided to me. The current strategy would fail to load these; instead this suffixes them so that they can all end up in the TrustManager.